### PR TITLE
Set port to 8080 (was 8081, same as mod-rs)

### DIFF
--- a/service/grails-app/conf/application-vagrant-db.yml
+++ b/service/grails-app/conf/application-vagrant-db.yml
@@ -34,5 +34,5 @@ dataSource:
 ---
 server:
   host: localhost
-  port: 8081
+  port: 8080
  


### PR DESCRIPTION
I have found in the last day or so that I am able to build and run (`./gradlew -Dgrails.env=vagrant-db bootRun`) _either_ mod-rs _or_ mod-directory, but not both, apparently because both want to listen on port 8081.

But based on running the UI against mod-directory, it also seems that it (or, rather, the Okapi that it's running again) expects mod-directory to be on port 8080: at least, that's my reading of the error message
> proxyRequestResponse failure: mod-directory-1.0.0 http://10.0.2.2:8080/: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: /10.0.2.2:8080 Headers:

So it looks to me as though mod-directory may have been accidentally changed to want to listen on port 8080 instead of 8081. Changing the last line of `mod-directory/service/grails-app/conf/application-vagrant-db.yml` to 8080 seems to fix the problem. But since this is all black magic to me, I'm submitting a PR rather than just pushing the fix, so someone who knows the code and/or the history can validate.