### PR TITLE
Reduce time to live for a directory entry to 2m - this is the minimum…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,21 @@ the migrations using one of the following commands:
     grails -Dgrails.env=dbGen dbm-generate-gorm-changelog my-new-changelog.groovy
 
 
+## Kubernetes Deployment Notes
+
+You may need to set OKAPI_SERVICE_PORT and/or OKAPI_SERVICE_HOST on the mod-licenses container.
+
+| Env var | Description | Default |
+| --- | --- | --- |
+|JAVA_OPTIONS|JDK Flags - N.B. MaxRAMPercentage|-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=55.0 -XX:+PrintFlagsFinal|
+|DB_HOST|Postgres DB host name|postgres|
+|DB_PORT|Postgres DB port|5432|
+|DB_USERNAME|Postgres DB username||
+|DB_PASSWORD|Postgres DB password||
+|DB_DATABASE|Postgres DB|okapi_modules|
+|DB_MAXPOOLSIZE|Max DB connection Pool size|50|
+|FOLIO_DIRECTORY_DEFUALTTTL|Default time to live for directory entry before a refresh can be attempted - default 2 mins|120000
+
+
+
 

--- a/service/grails-app/conf/application.yml
+++ b/service/grails-app/conf/application.yml
@@ -218,3 +218,6 @@ okapi:
     register: false
     deploy: false
 
+folio:
+  directory:
+    defualtttl: 120000  # min TTL in milliseconds for a directory entry to live before it can be tested for an updated - 2 mins

--- a/service/grails-app/services/org/olf/reshare/FoafService.groovy
+++ b/service/grails-app/services/org/olf/reshare/FoafService.groovy
@@ -28,8 +28,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 class FoafService implements DataBinder {
 
   def sessionFactory
+  def grailsApplication
 
-  private static long MIN_READ_INTERVAL = 60 * 60 * 24 * 2 * 1000; // 2 days between directory reads
+  private long MIN_READ_INTERVAL = 60 * 60 * 24 * 2 * 1000; // 2 days between directory reads
 
   // This is important! without it, all updates will be batched inside a single transaction and
   // we don't want that.
@@ -47,6 +48,11 @@ and gm.memberOrg.slug=:member
   public void init() {
     log.info("FoafService::init");
     executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(2);
+
+    if ( grailsApplication.config?.folio?.directory?.defualtttl ) {
+      MIN_READ_INTERVAL = Long.parseLong("${grailsApplication.config?.folio?.directory?.defualtttl}")?.longValue();
+    }
+    log.info("Default ttl for directory entries will be ${MIN_READ_INTERVAL}");
   }
 
   @javax.annotation.PreDestroy

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -737,8 +737,18 @@
     "dockerArgs": {
       "HostConfig": { "PortBindings": { "8080/tcp":  [{ "HostPort": "%p" }] } }
     },
+    "dockerPull" : false,
     "env": [
-      { "name": "JAVA_OPTIONS", "value": "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=55.0 -XX:+PrintFlagsFinal" }
+      { "name": "JAVA_OPTIONS", "value": "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=55.0 -XX:+PrintFlagsFinal" },
+      { "name": "DB_HOST", "value": "postgres" },
+      { "name": "DB_PORT", "value": "5432" },
+      { "name": "DB_USERNAME", "value": "folio_admin" },
+      { "name": "DB_PASSWORD", "value": "folio_admin" },
+      { "name": "DB_DATABASE", "value": "okapi_modules" },
+      { "name": "DB_MAXPOOLSIZE", "value": "50" },
+      { "name": "FOLIO_DIRECTORY_DEFUALTTTL", "value": "120000" }
+    ]
+
     ],
     "dockerPull" : false
   }


### PR DESCRIPTION
… time an entry can live before it becomes a candidate for refresh. Default timer task is still every 4h