### PR TITLE
feat: Validate DirectoryEntry

### DIFF
--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -10,7 +10,12 @@ class UrlMappings {
     "/directory/api/addFriend"(controller: 'application', action:'addFriend')
     "/directory/api/freshen"(controller: 'application', action:'freshen')
 
-    "/directory/entry"(resources:'directoryEntry')
+    "/directory/entry"(resources:'directoryEntry') {
+      collection {
+        "/validate" (controller: 'directoryEntry', action: 'validate')
+      }
+    }
+
     "/directory/symbol"(resources:'Symbol')
     "/directory/service"(resources:'Service')
     "/directory/serviceAccount"(resources:'ServiceAccount')

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -49,6 +49,11 @@
           "permissionsRequired" : [ "directory.entry.item.delete" ]
         },
         {
+          "methods": [ "POST" ],
+          "pathPattern": "/directory/entry/validate",
+          "permissionsRequired" : [ "directory.entry.item.post" ]
+        },
+        {
           "methods": [ "GET" ],
           "pathPattern": "/directory/symbol",
           "permissionsRequired" : [ "directory.symbol.collection.get" ]


### PR DESCRIPTION
Added a `validate` endpoint which allows direct validation of post values before attempting to actually POST a directory entry. In future this could be used to do real time field uniqueness validation, but it is currently used to surface warnings about counts of consorial and managed institution entries in the database.

PR-1107